### PR TITLE
fix GM_config version

### DIFF
--- a/packages/userscript/meta.json
+++ b/packages/userscript/meta.json
@@ -23,7 +23,7 @@
     "https://help.minecraft.net/hc/en-us/articles/*"
   ],
   "require": [
-    "https://fastly.jsdelivr.net/gh/sizzlemctwizzle/GM_config@master/gm_config.js"
+    "https://fastly.jsdelivr.net/gh/sizzlemctwizzle/GM_config@2207c5c1322ebb56e401f03c2e581719f909762a/gm_config.js"
   ],
   "grant": [
     "GM_setClipboard",


### PR DESCRIPTION
项目使用的依赖 GM_config 做出了一个[破坏性更新](https://github.com/sizzlemctwizzle/GM_config/issues/113)，根据相关 issuse，将依赖固定到未做变更前的版本。

大多数的油猴插件会缓存依赖，所以之前安装的不会受到影响。